### PR TITLE
Fixed dockerfile go-toolset version

### DIFF
--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -1,6 +1,6 @@
 # Uses a multi-stage container build to build ARO-Installer.
 ARG REGISTRY
-FROM ${REGISTRY}/ubi8/go-toolset:1.17.7 AS builder
+FROM ${REGISTRY}/ubi8/go-toolset:1.17.7-13 AS builder
 ENV GOOS=linux \
     GOPATH=/go/
 WORKDIR ${GOPATH}/src/github.com/hawkowl/ARO-Installer


### PR DESCRIPTION
Which issue this PR addresses:
Fixes live issue

What this PR does / why we need it:
When running the ARO-Installer dockerfile within the OneBranch pipelines it fails as it does not have access to the 1.17.10 go-toolset container, so downgrading to the 1.17.7-13 container instead.

Test plan for issue:
Manually

Is there any documentation that needs to be updated for this PR?
None